### PR TITLE
fix cipher desync issue

### DIFF
--- a/src/EterLib/NetStream.h
+++ b/src/EterLib/NetStream.h
@@ -72,6 +72,7 @@ class CNetworkStream
 		size_t Prepare(void* buffer, size_t* length);
 		bool Activate(size_t agreed_length, const void* buffer, size_t length);
 		void ActivateCipher();
+		void DecryptAlreadyReceivedData();
 #endif
 
 	private:

--- a/src/UserInterface/PythonNetworkStream.cpp
+++ b/src/UserInterface/PythonNetworkStream.cpp
@@ -587,7 +587,7 @@ bool CPythonNetworkStream::CheckPacket(TPacketHeader * pRetHeader)
 
 bool CPythonNetworkStream::RecvErrorPacket(int header)
 {
-	TraceError("Phase %s does not handle this header (header: %u(0x%X)) Last packets: ", m_strPhase.c_str(), header);
+	TraceError("Phase %s does not handle this header (header: %u(0x%X)) Last packets: ", m_strPhase.c_str(), header, header);
 	for (const auto& it : gs_vecLastHeaders)
 		TraceError("%u(0x%X)", it, it);
 

--- a/src/UserInterface/PythonNetworkStreamPhaseHandShake.cpp
+++ b/src/UserInterface/PythonNetworkStreamPhaseHandShake.cpp
@@ -254,6 +254,7 @@ bool CPythonNetworkStream::RecvKeyAgreementCompletedPacket()
 	Tracenf("KEY_AGREEMENT_COMPLETED RECV");
 
 	ActivateCipher();
+	DecryptAlreadyReceivedData();
 
 	return true;
 }


### PR DESCRIPTION
update the handshake phase to call the new method after activating the cipher, ensuring buffered data (likely from a second login attempt, GC_PHASE) is properly decrypted, and fix a logging format issue.