### PR TITLE
Fix fullscreen startup crash caused by WASAPI audio initialization

### DIFF
--- a/src/AudioLib/MaSoundInstance.h
+++ b/src/AudioLib/MaSoundInstance.h
@@ -1,4 +1,7 @@
 #pragma once
+#define MA_NO_WASAPI
+#define MA_ENABLE_DSOUND
+#define MA_ENABLE_WINMM
 #include <miniaudio.h>
 
 inline constexpr float CS_CLIENT_FPS = 61.0f;


### PR DESCRIPTION
The client was crashing during fullscreen initialization due to a NULL  IMMDeviceEnumerator pointer inside miniaudio’s WASAPI backend.

Crash location:
ma_IMMDeviceEnumerator_GetDefaultAudioEndpoint
(inlined in ma_device_init_internal__wasapi)

Disassembly showed a null vtable dereference:
call qword ptr [rax+20h]

On some systems, WASAPI fails to create or retrieve the default audio endpoint (especially in VMs, RDP sessions, missing/disabled audio devices, or timing issues during fullscreen initialization). This results in a NULL COM pointer  being used, causing a 0xC0000005 access violation before the game window fully  appears.

Solution:
WASAPI backend has been disabled and the client now falls back to the more stable  DirectSound/WinMM audio backends.

Applied definitions:
#define MA_NO_WASAPI
#define MA_ENABLE_DSOUND
#define MA_ENABLE_WINMM

Results:
✔ Fullscreen crash completely resolved
✔ Audio still works through DirectSound
✔ Improved stability across fullscreen/windowed modes
✔ No functional drawbacks observed