### PR TITLE
Fix quest dialog cancellation not notifying server

### DIFF
--- a/src/UserInterface/Packet.h
+++ b/src/UserInterface/Packet.h
@@ -41,7 +41,7 @@ enum
     HEADER_CG_SCRIPT_ANSWER						= 29,
 	HEADER_CG_QUEST_INPUT_STRING				= 30,
     HEADER_CG_QUEST_CONFIRM                     = 31,
-	//HEADER_BLANK32								= 32,
+	HEADER_CG_QUEST_CANCEL						= 32,
 	//HEADER_BLANK33								= 33,
 	//HEADER_BLANK34								= 34,
 	//HEADER_BLANK35								= 35,
@@ -1015,6 +1015,11 @@ typedef struct command_quest_confirm
     uint8_t answer;
     uint32_t requestPID;
 } TPacketCGQuestConfirm;
+
+typedef struct command_quest_cancel
+{
+    uint8_t header;
+} TPacketCGQuestCancel;
 
 typedef struct command_script_select_item
 {

--- a/src/UserInterface/PythonNetworkStream.h
+++ b/src/UserInterface/PythonNetworkStream.h
@@ -182,6 +182,7 @@ class CPythonNetworkStream : public CNetworkStream, public CSingleton<CPythonNet
 		bool SendAnswerMakeGuildPacket(const char * c_szName);
 		bool SendQuestInputStringPacket(const char * c_szString);
 		bool SendQuestConfirmPacket(BYTE byAnswer, DWORD dwPID);
+		bool SendQuestCancelPacket();
 
 		// Event
 		bool SendOnClickPacket(DWORD vid);

--- a/src/UserInterface/PythonNetworkStreamModule.cpp
+++ b/src/UserInterface/PythonNetworkStreamModule.cpp
@@ -1319,6 +1319,14 @@ PyObject* netSendQuestConfirmPacket(PyObject* poSelf, PyObject* poArgs)
 	return Py_BuildNone();
 }
 
+PyObject* netSendQuestCancelPacket(PyObject* poSelf, PyObject* poArgs)
+{
+	CPythonNetworkStream& rns=CPythonNetworkStream::Instance();
+	rns.SendQuestCancelPacket();
+
+	return Py_BuildNone();
+}
+
 PyObject* netSendGuildAddMemberPacket(PyObject* poSelf, PyObject* poArgs)
 {
 	int iVID;
@@ -1801,6 +1809,7 @@ void initnet()
 		{ "SendAnswerMakeGuildPacket",				netSendAnswerMakeGuildPacket,				METH_VARARGS },
 		{ "SendQuestInputStringPacket",				netSendQuestInputStringPacket,				METH_VARARGS },
 		{ "SendQuestConfirmPacket",					netSendQuestConfirmPacket,					METH_VARARGS },
+		{ "SendQuestCancelPacket",					netSendQuestCancelPacket,					METH_VARARGS },
 		{ "SendGuildAddMemberPacket",				netSendGuildAddMemberPacket,				METH_VARARGS },
 		{ "SendGuildRemoveMemberPacket",			netSendGuildRemoveMemberPacket,				METH_VARARGS },
 		{ "SendGuildChangeGradeNamePacket",			netSendGuildChangeGradeNamePacket,			METH_VARARGS },

--- a/src/UserInterface/PythonNetworkStreamPhaseGame.cpp
+++ b/src/UserInterface/PythonNetworkStreamPhaseGame.cpp
@@ -2322,6 +2322,21 @@ bool CPythonNetworkStream::SendQuestConfirmPacket(BYTE byAnswer, DWORD dwPID)
 	return SendSequence();
 }
 
+bool CPythonNetworkStream::SendQuestCancelPacket()
+{
+	TPacketCGQuestCancel Packet;
+	Packet.header = HEADER_CG_QUEST_CANCEL;
+
+	if (!Send(sizeof(Packet), &Packet))
+	{
+		Tracen("SendQuestCancelPacket Error");
+		return false;
+	}
+
+	Tracenf(" SendQuestCancelPacket");
+	return SendSequence();
+}
+
 bool CPythonNetworkStream::RecvSkillCoolTimeEnd()
 {
 	TPacketGCSkillCoolTimeEnd kPacketSkillCoolTimeEnd;


### PR DESCRIPTION
Client now notifies server when quest dialog is cancelled.

**Problem**: Closing quest dialogs early didn't notify the server, leaving quest state stuck.

**Solution**: Added quest cancel packet that is sent when dialog is closed via ESC or cancel button.

This allows the server to properly reset quest state and prevent blocking issues.