### PR TITLE
Never update selection cache to show only base stats in character selection

### DIFF
--- a/src/UserInterface/PythonNetworkStreamPhaseLoading.cpp
+++ b/src/UserInterface/PythonNetworkStreamPhaseLoading.cpp
@@ -177,14 +177,6 @@ bool CPythonNetworkStream::__RecvPlayerPoints()
 
 		if (i == POINT_LEVEL)
 			m_akSimplePlayerInfo[m_dwSelectedCharacterIndex].byLevel = PointsPacket.points[i];
-		else if (i == POINT_ST)
-			m_akSimplePlayerInfo[m_dwSelectedCharacterIndex].byST = PointsPacket.points[i];
-		else if (i == POINT_HT)
-			m_akSimplePlayerInfo[m_dwSelectedCharacterIndex].byHT = PointsPacket.points[i];
-		else if (i == POINT_DX)
-			m_akSimplePlayerInfo[m_dwSelectedCharacterIndex].byDX = PointsPacket.points[i];
-		else if (i == POINT_IQ)
-			m_akSimplePlayerInfo[m_dwSelectedCharacterIndex].byIQ = PointsPacket.points[i];
 	}
 
 	PyCallClassMemberFunc(m_apoPhaseWnd[PHASE_WINDOW_GAME], "RefreshStatus", Py_BuildValue("()"));


### PR DESCRIPTION
Problem fixed:
- Stats were wrong and did not account for equipment after login. You'd need to re-equip everything to have the updated stats.

This is part 1/2 (the other one is in server-src)
Some code copied over taken from the forum was conflicting with another copy-pasta from the forum

MRMJ-1 and MR-3 code was keeping the two parts of the code to not working as needed.

This removes the cache layer copy that would show the non-base stats in the character selection menu.
