### PR TITLE
MR-18: OverIn Tooltip and FreeType Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ This repository contains the source code necessary to compile the game client ex
 
 ## 📋 Changelog
 ### 🐛 Bug fixes
- - **Affect tooltips**: ALL affects now display realtime countdowns, titles and are wrapped in tooltips! Realtime countdowns does not apply to infinite affects such as the Exorcism Scroll, the Concentrated Reading and the Medal of the Dragon (Death penalty prevention)
- - **AFFECT_FIRE**: The Continuous Fire debuff has been added to the affects dictionary by name.
+ - **Fixed OverIn Tooltip when in front of another slot/window**: Public fix applied and extended to prevent hover events in quest letters when an overlay is currently in front of them (such as the Help window).
 
 <br>
 <br>

--- a/src/EterPythonLib/PythonSlotWindow.cpp
+++ b/src/EterPythonLib/PythonSlotWindow.cpp
@@ -691,9 +691,10 @@ void CSlotWindow::RefreshSlot()
 	OnRefreshSlot();
 
 	// NOTE : Refresh 될때 ToolTip 도 갱신 합니다 - [levites]
-	if (IsRendering())
+	if (IsRendering() && UI::CWindowManager::Instance().GetPointWindow() == this)
 	{
 		TSlot * pSlot;
+
 		if (GetPickedSlotPointer(&pSlot))
 		{
 			OnOverOutItem();

--- a/src/EterPythonLib/PythonWindow.cpp
+++ b/src/EterPythonLib/PythonWindow.cpp
@@ -1902,6 +1902,7 @@ namespace UI
 	void CButton::OnUpdate()
 	{
 	}
+
 	void CButton::OnRender()
 	{
 		if (!IsShow())
@@ -1910,7 +1911,7 @@ namespace UI
 		if (m_pcurVisual)
 		{
 			if (m_isFlash)
-			if (!IsIn())
+			if (!IsIn() || this != UI::CWindowManager::Instance().GetPointWindow())
 			if (int(timeGetTime() / 500)%2)
 			{
 				return;


### PR DESCRIPTION
- Fixed a wrong calculation of the centered vertical alignment causing text to distort when 2 different charsets were included (e.g., Arabic + English) in `GrptextInstance.cpp`
- Applied a minor public fix for preventing tooltip hovers to fire when a 2nd slot is rendered behind the targeted window and slot and extended the fix to `PythonWindow` for the same fix to be applied for quest letters when another window overlays them (e.g., the Help window)